### PR TITLE
fix: add dai-defi.co to blacklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -43893,6 +43893,7 @@
     "cryptoexio.top",
     "cryptoxet.com",
     "dai-defi.org",
+    "dai-defi.co",
     "defilaama.com",
     "doggieduck.com",
     "eth-networks.com",


### PR DESCRIPTION
I noticed some users accessed to the site on 11/8.