### PR TITLE
🔨 chore: implemented sync upstream schedule action

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: "0 2 * * *" # 10 AM UTC+8
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Sync upstream
+        run: |
+          gh repo sync CoolBitX-Technology/eth-phishing-detect --source MetaMask/eth-phishing-detect -b main --force
+        env:
+          GH_TOKEN: ${{ secrets.COOLWALLET_TEAM_GH_RELEASE }}


### PR DESCRIPTION
# Changes

- 將此 repo default branch 更改為 `cbx`
- 實作 sync-upstream action，台灣時間每天早上 10 點 從 MetaMask:main sync 至 CoolBitX:main

# Notes

- 為了讓我們的改動不要影響 main branch，開了 cbx branch 設定成 default 跑 schedule action
- 之後 contribute 記得要在 main branch 按，才不會把我們自己做的 action 改動更新到 MetaMask repo
- App 是從 main branch 抓釣魚網站黑名單，如果是想即時更新黑名單，要往 main branch 發 PR
- 即時更新的 PR merge 進 CoolBitX:main 之後，記得從 CoolBitX:main 往 MetaMask:main 也發 PR，不然隔天 sync 時，該名單會消失。此步驟之後可以再自動化，CoolBitX:main 有 PR 進就往 MetaMask:main 發 PR。
- sync 是 `Hard reset the branch of the destination repository to match the source repository`